### PR TITLE
feat: Added a reusable Heading Component

### DIFF
--- a/src/app/components/LargeHeading/index.tsx
+++ b/src/app/components/LargeHeading/index.tsx
@@ -1,6 +1,8 @@
-import { cva, VariantProps } from "class-variance-authority";
-import { cn } from "@/lib/utils";
 import { forwardRef, HTMLAttributes } from "react";
+import { cva, VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
 
 const headingVariants = cva(
   "text-black dark:text-white text-center lg:text-left font-extrabold leading-tight tracking-tighter",

--- a/src/app/components/LargeHeading/index.tsx
+++ b/src/app/components/LargeHeading/index.tsx
@@ -1,0 +1,36 @@
+import { cva, VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+import { forwardRef, HTMLAttributes } from "react";
+
+const headingVariants = cva(
+  "text-black dark:text-white text-center lg:text-left font-extrabold leading-tight tracking-tighter",
+  {
+    variants: {
+      size: {
+        default: "text-4xl md:text-5xl lg:text-6xl",
+        lg: "text-5xl md:text-6xl lg:text-7xl",
+        sm: "text-2xl md:text-3xl lg:text-4xl",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
+
+interface HeadingProps 
+extends HTMLAttributes<HTMLHeadingElement>,
+VariantProps<typeof headingVariants> {}
+
+const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
+  ({className, size, children, ...props}, ref) => (
+    <h1 ref={ref} {...props} className={cn(headingVariants({size, className}))}>{children}</h1>
+  )
+)
+
+Heading.displayName = `Heading`
+
+
+
+export default Heading
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,15 @@
 import { Inter } from 'next/font/google'
+import Heading from './components/LargeHeading'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export default function Home() {
   return (
     <main className="bg-red-600">
-      hello
+      {/* Only For Checking it, will be removed later  */}
+      <Heading>
+        Name Similarity API
+      </Heading>
     </main>
   )
 }


### PR DESCRIPTION
### Changes followed by this PR

* Task Link:- https://www.notion.so/js-shinobis/FE-LargeHeading-Reusable-Component-acf55ade87444e1c866d17b601126bf7?pvs=4
* A Reusable Heading component of 3 different sizes default, small and large

---

### Type of change

- [x] New feature (non-breaking change which adds functionality)

---

### Checklist:

<!---
Please delete options that are not relevant.
-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My commits are clean and follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) style.
- [x] I have created reusable components wherever possible.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
---

## Screenshots / GIFs (If any):

![LargeHeading](https://user-images.githubusercontent.com/108602441/233521589-d4a9e183-2fec-4933-b82c-4b08a67ef994.gif)


---
